### PR TITLE
Set a label on the loop that renders frames

### DIFF
--- a/playbooks/bad-apple.yml
+++ b/playbooks/bad-apple.yml
@@ -57,5 +57,5 @@
         msg: "{{ item }}"
       loop: "{{ result.results | map(attribute='frame') | list }}"
       loop_control:
+        label: frame
         pause: 0.0466
-...

--- a/playbooks/bad-apple.yml
+++ b/playbooks/bad-apple.yml
@@ -57,5 +57,6 @@
         msg: "{{ item }}"
       loop: "{{ result.results | map(attribute='frame') | list }}"
       loop_control:
-        label: frame
+        extended: true
+        label: "frame {{ ansible_loop.index }}/{{ ansible_loop.length }}"
         pause: 0.0466


### PR DESCRIPTION
This will prevent the ASCII render from displaying in-line as a loop item without line breaks, making the animation a bit cleaner :)

You can put other values in there, this is just an example:

Before:
![image](https://github.com/diademiemi/ansible_collection_diademiemi.bad_apple/assets/1291204/fc47baec-54c5-4966-938f-69bedbf470ff)

After:
![Screenshot from 2024-01-27 04-21-24](https://github.com/diademiemi/ansible_collection_diademiemi.bad_apple/assets/1291204/9fa25da9-5d2a-494e-aa28-da603e6765a1)
